### PR TITLE
Regenerate legacy/genomes.json (restores mm10 and hg18 fasta index URLs)

### DIFF
--- a/genomes/legacy/genomes.json
+++ b/genomes/legacy/genomes.json
@@ -160,8 +160,8 @@
 {
   "id": "hg18",
   "name": "Human (hg18)",
-  "fastaURL": "https://igv.org/genomes/hg18/hg18.fasta",
-  "indexURL": "https://igv.org/genomes/hg18/hg18.fasta.fai",
+  "fastaURL": "https://igv.org/genomes/data/hg18/hg18.fasta",
+  "indexURL": "https://igv.org/genomes/data/hg18/hg18.fasta.fai",
   "cytobandURL": "https://hgdownload.soe.ucsc.edu/goldenPath/hg18/database/cytoBandIdeo.txt.gz",
   "tracks": [
     {
@@ -202,7 +202,7 @@
   "id": "mm10",
   "name": "Mouse (GRCm38/mm10)",
   "fastaURL": "https://igv.org/genomes/data/mm10/mm10.fa",
-  "indexURL": "https://igv.org/genomes/data/mm10.fa.fai",
+  "indexURL": "https://igv.org/genomes/data/mm10/mm10.fa.fai",
   "cytobandURL": "https://hgdownload.soe.ucsc.edu/goldenPath/mm10/database/cytoBandIdeo.txt.gz",
   "twoBitURL": "https://hgdownload.soe.ucsc.edu/goldenPath/mm10/bigZips/mm10.2bit",
   "chromSizesURL": "https://hgdownload.soe.ucsc.edu/goldenPath/mm10/bigZips/mm10.chrom.sizes",


### PR DESCRIPTION
The per-genome sources under `genomes/legacy/json/` are correct, but the aggregate `genomes/legacy/genomes.json` has not been rebuilt since they were last fixed, so two genomes still point at fasta indexes that 404.

`mm10.json` was fixed in 5f62c9a (2026-06-03 05:15Z), but `legacy/genomes.json` was last written in 85d606b at 03:43Z — about 1.5 hours earlier. `hg18` is stale in the same way.

This PR is just the output of the existing build script, with no hand edits:

```
scripts/buildGenomesJson.sh genomes/legacy/web_genomes.txt
```

The regenerated file is byte-identical to the committed one apart from the two entries whose sources have since changed: the diff is +3/-3 lines, the file grows by exactly 15 bytes (3 × the 5 characters added to those paths), line endings are unchanged, and it still holds the same 42 entries in the same order. Nothing else moves.

```diff
 "id": "hg18",
-"fastaURL": "https://igv.org/genomes/hg18/hg18.fasta",
-"indexURL": "https://igv.org/genomes/hg18/hg18.fasta.fai",
+"fastaURL": "https://igv.org/genomes/data/hg18/hg18.fasta",
+"indexURL": "https://igv.org/genomes/data/hg18/hg18.fasta.fai",

 "id": "mm10",
-"indexURL": "https://igv.org/genomes/data/mm10.fa.fai",
+"indexURL": "https://igv.org/genomes/data/mm10/mm10.fa.fai",
```

Current status of the URLs involved (checked 2026-07-21):

| URL | status |
|---|---|
| `igv.org/genomes/data/mm10.fa.fai` (in the served file) | 404 |
| `igv.org/genomes/data/mm10/mm10.fa.fai` (after this PR) | 200 |
| `igv.org/genomes/hg18/hg18.fasta[.fai]` (in the served file) | 404 |
| `igv.org/genomes/data/hg18/hg18.fasta[.fai]` (after this PR) | 200 |

This matters beyond the repo: `https://igv.org/genomes/genomes.json`, which igv.js 2.x loads at startup, is currently byte-identical to this file. mm10 therefore fails to display in any igv.js 2.x embedding — that is how we ran into it (gladkia/igvShiny#107). Because the failing paths return no CORS headers, the browser reports `net::ERR_FAILED` rather than a 404, which makes it look like a client bug.

danRer11 and rn6 are broken in the same file but are not build staleness — their sources point at locations that are genuinely gone. Filed separately.
